### PR TITLE
Testing inclusion of setterm

### DIFF
--- a/rokuterm.py
+++ b/rokuterm.py
@@ -22,7 +22,7 @@ else:
 
 
 ip = ""
-version = "0.2.1"
+version = "0.2.2"
 
 #KB hit routines START
 # save the terminal settings

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: rokuterm
-version: 0.2.1
+version: 0.2.2
 summary: A Roku remote for terminal
 description: Control your Roku or Now TV box in your terminal
 confinement: strict
@@ -15,6 +15,11 @@ parts:
     python-version: python2
     source: https://github.com/cliftonts/RokuTerm.git
     python-packages: [requests]
+    stage-packages: setterm
+    filesets:
+       setterm: usr/bin/setterm
+    stage: $setterm
+    snap: Ssetterm
     install: |
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       cp rokuterm.py $SNAPCRAFT_PART_INSTALL/bin/


### PR DESCRIPTION
Setterm is required to be packaged to solve the non removal of
the cursor in snaps. This commit  is testing the yaml file.